### PR TITLE
Optimize the nonce-skipping algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ public_key.pem
 blocks/
 .idea
 src/db/latest_block_hash
-nonce_list.txt
+nonce_list
+start_nonce

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 p2pnetwork==1.1
 pycryptodome==3.12.0
 ecdsa==0.17.0
+scikit-learn==1.1.1
+numpy==1.22.4

--- a/src/db/mapper.py
+++ b/src/db/mapper.py
@@ -8,6 +8,7 @@ class Mapper():
         os.path.realpath(__file__)) + "/blocks"
     latest_block_hash_file = os.path.dirname(
         os.path.realpath(__file__)) + "/latest_block_hash"
+    db_dir = os.path.dirname(os.path.realpath(__file__))
 
     @staticmethod
     def write_block(hash, block):
@@ -30,7 +31,8 @@ class Mapper():
     def read_latest_block_hash():
         try:
             with open(Mapper.latest_block_hash_file) as file:
-                return file.read()
+                data = file.read()
+            return data.replace("\n", "")  # Remove any EOL characters
         except EOFError:
             logging.error("Unable to read latest-block-hash")
 
@@ -41,3 +43,44 @@ class Mapper():
                 file.write(str(hash))
         except EOFError:
             logging.error("Unable to write latest-block-hash")
+
+    @staticmethod
+    def read_nonce_list():
+        try:
+            with open(Mapper.db_dir + "/nonce_list") as file:
+                data = file.read()
+            return data
+        except FileNotFoundError:
+            # create the file
+            with open(Mapper.db_dir + "/nonce_list", "a") as file:
+                pass
+            return None
+
+    @staticmethod
+    def append_to_nonce_list(nonce):
+        try:
+            with open(Mapper.db_dir + "/nonce_list", "a") as file:
+                file.write(str(nonce) + "\n")
+        except EOFError:
+            logging.error("Unable to write nonce list")
+
+    @staticmethod
+    def read_latest_start_nonce():
+        try:
+            with open(Mapper.db_dir + "/start_nonce") as file:
+                data = file.read()
+            if data:
+                return data.replace("\n", "")   # remove any EOF characters just in case
+        except FileNotFoundError:
+            # create the file
+            with open(Mapper.db_dir + "/start_nonce", "a") as file:
+                pass
+        return 0
+
+    @staticmethod
+    def write_latest_start_nonce(nonce):
+        try:
+            with open(Mapper.db_dir + "/start_nonce", "wb") as file:
+                file.write(nonce)
+        except EOFError:
+            logging.error("Unable to write start nonce")

--- a/src/tests/test_mining.py
+++ b/src/tests/test_mining.py
@@ -23,16 +23,19 @@ logging.disable(logging.CRITICAL)   # disable all logging from main.py
 class TestMining(TestCase):
 
     DIFFICULTY = 4
-    NO_OF_BLOCKS = 98
+    NO_OF_BLOCKS = 50
     print(f'test for {NO_OF_BLOCKS} blocks with difficulty {DIFFICULTY}')
 
     def test_mine_with_bruteforce(self):
         ''' Find the nonce for each block using bruteforce '''
 
         all_iterations = []
-        # create 99 transactions and increment the amount each time
-        for i in range(1, self.NO_OF_BLOCKS + 1):
-            tx = Transaction('bob', 'alice', float(i), datetime(2022, 1, 1, 0, 0, 0))
+        start = datetime.now()  # FIXME this is inaccurate, but is enough to get a rough estimation
+
+        for i in range(self.NO_OF_BLOCKS):
+            tx = Transaction(str(i), 'alice', 1.0, datetime(2022, 1, 1, 0, 0, 0))
+            # tx = Transaction('bob', str(i), 1.0, datetime(2022, 1, 1, 0, 0, 0))
+            # tx = Transaction(str(i), str(i), 1.0, datetime(2022, 1, 1, 0, 0, 0))
             tx_hash = tx.hash()
             private_key = SigningKey.generate(curve=SECP256k1, hashfunc=sha256)
             pubkey = private_key.get_verifying_key()
@@ -43,14 +46,19 @@ class TestMining(TestCase):
             block = Block(transactions=[tx])    # put the tx in a block and mine it
             iterations = block.find_nonce(difficulty=self.DIFFICULTY, method='bruteforce')
             all_iterations.append(iterations)
+
         print("Average iterations for bruteforce:\t", sum(all_iterations) / len(all_iterations))
+        print(f"took {datetime.now() - start}")
 
     def test_mine_with_nonce_skipping(self):
         ''' Find the nonce and the number of iterations for each block by skipping prev. nonces '''
         all_iterations = []
-        # create 99 transactions and increment the amount each time
-        for i in range(1, self.NO_OF_BLOCKS + 1):
-            tx = Transaction('bob', 'alice', float(i), datetime(2022, 1, 1, 0, 0, 0))
+        start = datetime.now()
+
+        for i in range(self.NO_OF_BLOCKS):
+            tx = Transaction(str(i), 'alice', 1.0, datetime(2022, 1, 1, 0, 0, 0))
+            # tx = Transaction('bob', str(i), 1.0, datetime(2022, 1, 1, 0, 0, 0))
+            # tx = Transaction(str(i), str(i), 1.0, datetime(2022, 1, 1, 0, 0, 0))
             tx_hash = tx.hash()
             private_key = SigningKey.generate(curve=SECP256k1, hashfunc=sha256)
             pubkey = private_key.get_verifying_key()
@@ -61,14 +69,16 @@ class TestMining(TestCase):
             block = Block(transactions=[tx])    # put the tx in a block and mine it
             block.find_nonce(difficulty=self.DIFFICULTY, method='nonce-skip')
             all_iterations.append(block.iterations)
+
         print("Average iterations for nonce-skip:\t", sum(all_iterations) / len(all_iterations))
+        print(f"took {datetime.now() - start}")
 
     def mine_with_bitshift(self):
         ''' Find the nonce and the number of iterations for each block using bitshifting '''
         all_iterations = []
         # create 99 transactions and increment the amount each time
-        for i in range(1, self.NO_OF_BLOCKS + 1):
-            tx = Transaction('bob', 'alice', float(i), datetime(2022, 1, 1, 0, 0, 0))
+        for i in range(self.NO_OF_BLOCKS):
+            tx = Transaction(str(i), 'alice', 1.0, datetime(2022, 1, 1, 0, 0, 0))
             tx_hash = tx.hash()
             private_key = SigningKey.generate(curve=SECP256k1, hashfunc=sha256)
             pubkey = private_key.get_verifying_key()


### PR DESCRIPTION
* Cluster the nonce list every 5 blocks and save the start nonce in between
* Move file I/O to the Mapper for better separation of concerns
* Improve access to the nonce list by only reading one element at a time
* Clean up the unittest code
* Update requirements.txt
* Update gitignore

Co-authored-by: Tobias Heim Galindo <tobisellfy@gmail.com>
Co-authored-by: Tim Habeck <th135@hdm-stuttgart.de>